### PR TITLE
Remove cjson dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,11 @@ That allows you to write a socket client in your favorite language to wrap api f
 ## Requirements
 
 * luasockets
-* lua-cjson
 
 ### Installation with Windows
 
 It's more complicated, because you can't just put some dlls in the right place. 
-You have to recompile minetest together with luasocket and lua-cjson. 
+You have to recompile minetest together with luasocket. 
 
 Luckily there are some scripts to do that for you or you just download a precompiled binary that includes all you need.
 
@@ -35,7 +34,7 @@ Luckily there are some scripts to do that for you or you just download a precomp
 
 The latest minetest version is in the backport repository for buster, so it's very easy to install: https://wiki.minetest.net/Setting_up_a_server/Debian
 ```
-apt install lua-socket lua-cjson
+apt install lua-socket
 cd /var/games/minetest-server/.minetest/mods
 git clone git@github.com:miney-py/mineysocket.git
 ```
@@ -45,7 +44,7 @@ load_mod_mineysocket = true
 ```
 * Edit /etc/minetest/minetest.conf
   * name = \<your_playername\>  # This gives you all privileges on your server
-  * secure.trusted_mods = mineysocket  # This is needed for luasocket and lua-cjson
+  * secure.trusted_mods = mineysocket  # This is needed for luasocket
   * Optional but recommended:
     * enable_rollback_recording = true  # This allows you to clean up your world
 * Connect at least once with minetest to your server and login with a username + password, to get you registered.

--- a/init.lua
+++ b/init.lua
@@ -46,10 +46,6 @@ local luasocket = ie.require("socket.core")
 if not luasocket then
   error("luasocket is not installed or was not found...")
 end
-mineysocket.json = ie.require("cjson")
-if not mineysocket.json then
-  error("lua-cjson is not installed or was not found...")
-end
 
 -- setup network server
 local server, err = luasocket.tcp()
@@ -188,11 +184,11 @@ mineysocket.receive = function()
         end
 
         -- parse data as json
-        local status, input = pcall(mineysocket.json.decode, data)
+        local status, input = pcall(minetest.parse_json, data)
         if not status then
-          minetest.log("error", "mineysocket: " .. mineysocket.json.encode({ error = input }))
+          minetest.log("error", "mineysocket: " .. minetest.write_json({ error = input }))
           mineysocket.log("error", "JSON-Error: " .. input, ip, port)
-          mineysocket.send(clientid, mineysocket.json.encode({ error = "JSON decode error - " .. input }))
+          mineysocket.send(clientid, minetest.write_json({ error = "JSON decode error - " .. input }))
           return
         end
 
@@ -229,9 +225,9 @@ mineysocket.receive = function()
 
           -- send result
           if result ~= false then
-            mineysocket.send(clientid, mineysocket.json.encode(result))
+            mineysocket.send(clientid, minetest.write_json(result))
           else
-            mineysocket.send(clientid, mineysocket.json.encode({ error = "Unknown command" }))
+            mineysocket.send(clientid, minetest.write_json({ error = "Unknown command" }))
           end
 
         else
@@ -239,7 +235,7 @@ mineysocket.receive = function()
           if input["playername"] and input["password"] then
             mineysocket.send(clientid, mineysocket.authenticate(input, clientid, ip, port, socket_clients[clientid].socket))
           else
-            mineysocket.send(clientid, mineysocket.json.encode({ error = "Unknown command" }))
+            mineysocket.send(clientid, minetest.write_json({ error = "Unknown command" }))
           end
         end
       end
@@ -273,7 +269,7 @@ function run_lua(input, clientid, ip, port)
     if status then
       output["result"] = { result1, result2, result3, result4, result5 }
       if mineysocket.debug then
-        local json_output = mineysocket.json.encode(output)
+        local json_output = minetest.write_json(output)
         if string.len(json_output) > 120 then
           mineysocket.log("action", string.sub(json_output, 0, 120) .. " ..." .. " in " .. (minetest.get_server_uptime() - start_time) .. " seconds", ip, port)
         else
@@ -374,8 +370,8 @@ mineysocket.send_event = function(data)
 
   for clientid, values in pairs(socket_clients) do
     if has_value(socket_clients[clientid].events, data["event"][1]) then
-      mineysocket.log("action", "Sending event: " .. mineysocket.json.encode(data["event"][1]))
-      mineysocket.send(clientid, mineysocket.json.encode(data))
+      mineysocket.log("action", "Sending event: " .. minetest.write_json(data["event"][1]))
+      mineysocket.send(clientid, minetest.write_json(data))
     end
   end
 end


### PR DESCRIPTION
mineysocket depends on lua-cjson. However, minetest has an integrated JSON API accessible through minetest.write_json and minetest.parse_json.

This PR replaces the respective method calls and removes all references to lua-csjon from README.